### PR TITLE
chore(http-client): Receive http client as param

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -37,7 +37,7 @@ var (
 
 // Interface for instantiating and interacting with an FcmClient
 type FcmClienty interface {
-	NewFcmClient(string) FcmClienty
+	NewFcmClient(string, *http.Client) FcmClienty
 
 	NewFcmTopicMsg(string, map[string]string) FcmClienty
 	NewFcmMsgTo(string, interface{}) FcmClienty
@@ -59,6 +59,7 @@ type FcmClienty interface {
 // FcmClient stores the key and the Message (FcmMsg)
 type FcmClient struct {
 	ApiKey  string
+	Client  *http.Client
 	Message FcmMsg
 }
 
@@ -110,16 +111,17 @@ type NotificationPayload struct {
 }
 
 // NewFcmClient inits and creates fcm client using exported interface
-func NewFcmClient(apiKey string) *FcmClient {
+func NewFcmClient(apiKey string, client *http.Client) *FcmClient {
 	fcmc := new(FcmClient)
 	fcmc.ApiKey = apiKey
+	fcmc.Client = client
 
 	return fcmc
 }
 
 // NewFcmClient init and create fcm client
-func (this *FcmClient) NewFcmClient(apiKey string) FcmClienty {
-	return NewFcmClient(apiKey)
+func (this *FcmClient) NewFcmClient(apiKey string, client *http.Client) FcmClienty {
+	return NewFcmClient(apiKey, client)
 }
 
 // NewFcmTopicMsg sets the targeted token/topic and the data payload
@@ -192,16 +194,7 @@ func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
 	request.Header.Set("Authorization", this.apiKeyHeader())
 	request.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{
-		Timeout: 1 * time.Second,
-		Transport: &http.Transport{
-			IdleConnTimeout:     1 * time.Minute,
-			MaxIdleConnsPerHost: 500,
-			MaxIdleConns:        0,
-			MaxConnsPerHost:     0,
-		},
-	}
-	response, err := client.Do(request)
+	response, err := this.Client.Do(request)
 
 	if err != nil {
 		return fcmRespStatus, err

--- a/fcm.go
+++ b/fcm.go
@@ -192,7 +192,15 @@ func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
 	request.Header.Set("Authorization", this.apiKeyHeader())
 	request.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 1 * time.Second,
+		Transport: &http.Transport{
+			IdleConnTimeout:     1 * time.Minute,
+			MaxIdleConnsPerHost: 500,
+			MaxIdleConns:        0,
+			MaxConnsPerHost:     0,
+		},
+	}
 	response, err := client.Do(request)
 
 	if err != nil {
@@ -384,4 +392,4 @@ func (this *FcmResponseStatus) GetRetryAfterTime() (t time.Duration, e error) {
 func (this *FcmClient) SetCondition(condition string) FcmClienty {
 	this.Message.Condition = condition
 	return this
-} 
+}

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -13,7 +13,7 @@ func TestTopicHandle_1(t *testing.T) {
 	chgUrl(srv)
 	defer srv.Close()
 
-	c := NewFcmClient("key")
+	c := NewFcmClient("key", &http.Client{})
 
 	data := map[string]string{
 		"msg": "Hello World",
@@ -37,7 +37,7 @@ func TestTopicHandle_2(t *testing.T) {
 	chgUrl(srv)
 	defer srv.Close()
 
-	c := NewFcmClient("key")
+	c := NewFcmClient("key", &http.Client{})
 
 	data := map[string]string{
 		"msg": "Hello World",
@@ -61,7 +61,7 @@ func TestTopicHandle_3(t *testing.T) {
 	chgUrl(srv)
 	defer srv.Close()
 
-	c := NewFcmClient("key")
+	c := NewFcmClient("key", &http.Client{})
 
 	data := map[string]string{
 		"msg": "Hello World",
@@ -90,7 +90,7 @@ func TestRegIdHandle_1(t *testing.T) {
 	chgUrl(srv)
 	defer srv.Close()
 
-	c := NewFcmClient("key")
+	c := NewFcmClient("key", &http.Client{})
 
 	data := map[string]string{
 		"msg": "Hello World",
@@ -124,7 +124,7 @@ func TestRegIdHandle_2(t *testing.T) {
 	chgUrl(srv)
 	defer srv.Close()
 
-	c := NewFcmClient("key")
+	c := NewFcmClient("key", &http.Client{})
 
 	data := map[string]string{
 		"msg": "Hello World",


### PR DESCRIPTION
**Purpose**

Receive a `http.Client` as a param to allow each application to set it's timeouts and metrics.